### PR TITLE
Fixes Issue #2 that I was having

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -81,7 +81,7 @@ is_r_version = function(target_version, compare_major_minor = TRUE) {
         R.version$minor
     }
 
-    version_string = paste(R.version$major, minor_value)
+    version_string = paste(R.version$major, minor_value, sep = ".")
     return(version_string == target_version)
 }
 


### PR DESCRIPTION
The `version_string` object was being returned as "4 2", not "4.2" on my M1 Air. The comparison checks that `version_string == target_version`, or on my system it was returning `4 2 == 4.2` on line 85. This fixes that so you get `"4.2" == "4.2"`.

I've successfully run `macrtools::macos_rtools_install()` locally after making these changes and reinstalling the modified package.

```r
Congratulations!
Xcode CLI, Gfortran, and R developer binaries have been installed successfully.
```