### PR TITLE
Fix macOS 26.x version check to allow subversions (e.g., 26.0.1) in is_macos_r_supported

### DIFF
--- a/R/system.R
+++ b/R/system.R
@@ -52,7 +52,7 @@ shell_mac_version <- function() {
 #' @keywords internal
 is_macos_r_supported <- function() {
     mac_version <- shell_mac_version()
-    version_between(mac_version, "10.13.0", "26.0")
+    version_between(mac_version, "10.13.0", "27.0")
 }
 
 #' Check if macOS Tahoe


### PR DESCRIPTION
Trying to run `macrtools::macos_rtools_install()` on macOS 26.0.1 yields the below error:
```
Error in `macrtools::macos_rtools_install()`:
! macrtools: Your macOS version "26.0.1" is not supported.
macrtools: Supported versions: macOS High Sierra (10.13) through macOS Tahoe
(26.x).
Run `rlang::last_trace()` to see where the error occurred.
```

**What was fixed:**
The upper bound in is_macos_r_supported() was changed from "26.0" to "27.0", permitting all 26.x.y macOS versions (such as 26.0.1).